### PR TITLE
Simplify GitHub Actions configuration

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -3,44 +3,16 @@ name: Build
 on: [ push ]
 
 jobs:
-  #Ubuntu
-  build_212-ubuntu:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        scala: [ 2.12.15, 2.13.7 ]
+        os: [ ubuntu-latest, windows-latest ] 
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - run: sbt '++ 2.12.15 clean; compile'
-
-  build_213-ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - run: sbt '++ 2.13.7 clean; compile'
-
-  #Windows
-  build_212-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - run: sbt '++ 2.12.15 clean; compile'
-
-  build_213-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - run: sbt '++ 2.13.7 clean; compile'
+      - run: sbt '++ ${{ matrix.scala }} clean; compile'


### PR DESCRIPTION
This just cleans up the configuration to use a matrix instead of four separate jobs. The final behavior is the same, but the config file is much shorter.